### PR TITLE
Fixed PhpGenerator namespace (Nette aliases this automatically and preserves BC)

### DIFF
--- a/src/Kdyby/Curl/DI/CurlExtension.php
+++ b/src/Kdyby/Curl/DI/CurlExtension.php
@@ -12,7 +12,7 @@ namespace Kdyby\Curl\DI;
 
 use Kdyby;
 use Nette;
-use Nette\PhpGenerator as Code;
+use Nette\Utils\PhpGenerator as Code;
 
 
 


### PR DESCRIPTION
As discussed in #3
