### PR TITLE
Request::DOWNLOAD method is preserved in redirect

### DIFF
--- a/src/Kdyby/Curl/Request.php
+++ b/src/Kdyby/Curl/Request.php
@@ -248,7 +248,9 @@ class Request extends RequestOptions
 	final public function followRedirect(Response $response)
 	{
 		$request = clone $this;
-		$request->setMethod(Request::GET);
+		if (!$request->isMethod(Request::DOWNLOAD)) {
+			$request->setMethod(Request::GET);
+		}
 		$request->post = $request->files = array();
 		$request->cookies = $response->getCookies() + $request->cookies;
 		$request->setUrl(static::fixUrl($request->getUrl(), $response->headers['Location']));


### PR DESCRIPTION
When I make DOWNLOAD request, follow redirect and get response with Location header, I get an error:
`Kdyby\Curl\InvalidStateException: File '.headers' not readable. in ..../Kdyby/Curl/FileResponse.php:174`

I've solved the problem with preserving Request method in Curl\Request::followRedirect().

Now everything works fine.

---

I didn't write tests because it's impossible do that.
