### PR TITLE
Implemented detection of IP resolve option for interface

### DIFF
--- a/src/Kdyby/Curl/CurlWrapper.php
+++ b/src/Kdyby/Curl/CurlWrapper.php
@@ -456,8 +456,31 @@ class CurlWrapper extends Nette\Object
 
 		// set options
 		curl_setopt($this->handle, CURLINFO_HEADER_OUT, TRUE);
+		$interface = NULL;
+		$ipResolve = NULL;
 		foreach ($this->options as $option => $value) {
 			curl_setopt($this->handle, constant('CURLOPT_' . strtoupper($option)), $value);
+			if (strtolower($option) === 'interface') {
+				$interface = $value;
+			} elseif (strtolower($option) === 'ipresolve') {
+				$ipResolve = $value;
+			}
+		}
+
+		if ($interface !== NULL) {
+			if (filter_var($interface, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) !== FALSE) {
+				if ($ipResolve === NULL) {
+					curl_setopt($this->handle, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
+				} elseif ($ipResolve !== CURL_IPRESOLVE_V4) {
+					throw new CurlException('Try of usage not IPv4 resolving using IPv4 address has been detected. It would not work so please change ipResolve or interface option for cURL.');
+				}
+			} elseif (filter_var($interface, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== FALSE) {
+				if ($ipResolve === NULL) {
+					curl_setopt($this->handle, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V6);
+				} elseif ($ipResolve !== CURL_IPRESOLVE_V6) {
+					throw new CurlException('Try of usage not IPv6 resolving using IPv6 address has been detected. It would not work so please change ipResolve or interface option for cURL.');
+				}
+			}
 		}
 
 		return $this->handle;


### PR DESCRIPTION
`CURLOPT_INTERFACE` defines output network interface or IP address. However when machine the code is running on has IPv4 address(es) and IPv6 address(es) together then it brings WTF bug. The IPv6 address is preferred somehow.

The bug reveals itself when the machine tries to connect to server with both IP address versions too. So let's say you want to use your public IPv4 to connect to some API instead of using your IPv6. If the API server has public IPv6 address then the request fails on "couldn't bind to <ip>". You have to tell curl which version you want to use and then it works correctly. This is required because default value of `CURLOPT_IPRESOLVE` is `whatever`.

The new code helps you because you do not have to think about it anymore.