### PR TITLE
Fixed creating cookie from string

### DIFF
--- a/src/Kdyby/Curl/HttpCookies.php
+++ b/src/Kdyby/Curl/HttpCookies.php
@@ -36,7 +36,7 @@ class HttpCookies extends ArrayHash
 	 */
 	public function __construct($setCookies = NULL)
 	{
-		if (Nette\Utils\Validators::isList($setCookies)) {
+		if (Nette\Utils\Validators::isList($setCookies) || is_scalar($setCookies)) {
 			$this->parse(is_array($setCookies) ? $setCookies : (array)$setCookies);
 
 		} else {


### PR DESCRIPTION
Incorrect cookie parsing if a string is supplied as the $setCookies parameter. The string was parsed like an associative array.